### PR TITLE
single-line fix

### DIFF
--- a/src/cs2solutions/aircraft.py
+++ b/src/cs2solutions/aircraft.py
@@ -65,7 +65,7 @@ def test_aircraft_state_space(student_sol: callable, actual_sol: callable, shoul
     sol_model = actual_sol()
 
     # Check if the student's state space model is an instance of the StateSpace class
-    assert isinstance(student_model, None), f"Please make sure to return a StateSpace object. Got {type(student_model)} instead."
+    assert isinstance(student_model, type(None)), f"Please make sure to return a StateSpace object. Got {type(student_model)} instead."
     assert isinstance(student_model, ct.StateSpace), f"Expected a StateSpace object, but got {type(student_model)}"
 
     # Check if the student's state space model is equal to the solution state space model


### PR DESCRIPTION
literally a single line. 

could not find another instance of isinstance(..., None) _(hah get it)_ anywhere. 

isinstance(..., None) does not work on <=Python 3.9, therefore replaced with isinstance(..., type(None))